### PR TITLE
Fix Windows/GCC build: compiler flag and initializer ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,11 @@ else()
     # Non-Windows debug build with sanitizers
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3 -ggdb3 -fsanitize=address,undefined -fno-omit-frame-pointer -Werror=reorder-init-list")
 endif()
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Werror=reorder-init-list")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Werror=reorder-init-list")
+else()
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+endif()
 
 # When using sanitizers, we need to link with them too
 #if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/videosystem.hpp
+++ b/src/videosystem.hpp
@@ -78,9 +78,9 @@ struct video_system_t {
     SDL_FRect last_srcrect = { 0.0f, 0.0f, 0.0f, 0.0f };
 
     RGBA_t mono_color_table[DM_NUM_MONO_MODES] = {
-        {.a=0xFF, .b=0xFF, .g=0xFF, .r=0xFF }, // white
-        {.a=0xFF, .b=0x4A, .g=0xFF, .r=0x00 }, // green (was 55) chosen from measuring @ 549nm and https://academo.org/demos/wavelength-to-colour-relationship/
-        {.a=0xFF, .b=0x00, .g=0xBF, .r=0xFF }  // amber
+        RGBA_t::make(0xFF, 0xFF, 0xFF), // white
+        RGBA_t::make(0x00, 0xFF, 0x4A), // green (was 55) chosen from measuring @ 549nm
+        RGBA_t::make(0xFF, 0xBF, 0x00)  // amber
     };
    /*  uint32_t mono_color_table_u[DM_NUM_MONO_MODES] = { // NO LONGER USED
         0xFFFFFFFF, // white


### PR DESCRIPTION
## Summary
- Guard `-Werror=reorder-init-list` behind Clang check — GCC doesn't support this flag, causing build failure on MinGW/MSYS2
- Fix `mono_color_table` designated initializer order in `videosystem.hpp` — field order `{.a, .b, .g, .r}` didn't match the `RGBA_t` struct layout on Windows (BGRA). Using `RGBA_t::make(r, g, b)` handles platform byte ordering correctly on all targets

## Test plan
- [x] Full build verified on Windows with MinGW GCC 15.2.0 (MSYS2)
- [ ] Verify no change on macOS/Clang (Clang still gets `-Werror=reorder-init-list`)
- [ ] Verify mono colors render correctly (white, green, amber)

🤖 Generated with [Claude Code](https://claude.com/claude-code)