### PR TITLE
Read the ADB mouse cursor from the Event Manager bank globals

### DIFF
--- a/src/devices/adb/keygloo_mouse_sync.hpp
+++ b/src/devices/adb/keygloo_mouse_sync.hpp
@@ -75,10 +75,17 @@ inline bool shr_320_mode(MMU_II *megaii) {
 }
 
 inline void read_em_mouse_pos(MMU_II *mmu, int &x, int &y) {
-    uint8_t x_lo = read_megaii_linear(mmu, EM_MOUSE_X_LO);
-    uint8_t x_hi = read_megaii_linear(mmu, EM_MOUSE_X_HI);
-    uint8_t y_lo = read_megaii_linear(mmu, EM_MOUSE_Y_LO);
-    uint8_t y_hi = read_megaii_linear(mmu, EM_MOUSE_Y_HI);
+    // Read the $E1/0190-0193 bank globals, not the $E0 text-page screen
+    // holes ($047C/...): observed live against GS/OS 6.0.1 (ROM 03 boot),
+    // the Event Manager maintains its cursor position only in the bank
+    // globals — the screen-hole copies stay 0. Reading the holes made the
+    // closed-loop stepper's feedback stick at (0,0), so it never saw its
+    // steps land and drove the cursor to the bottom-right corner
+    // (stale_frames re-injects after 4 frames) instead of converging.
+    uint8_t x_lo = read_megaii_linear(mmu, EM_MOUSE_X_LO_BANK);
+    uint8_t x_hi = read_megaii_linear(mmu, EM_MOUSE_X_HI_BANK);
+    uint8_t y_lo = read_megaii_linear(mmu, EM_MOUSE_Y_LO_BANK);
+    uint8_t y_hi = read_megaii_linear(mmu, EM_MOUSE_Y_HI_BANK);
     x = x_lo | (x_hi << 8);
     y = y_lo | (y_hi << 8);
 }


### PR DESCRIPTION
`read_em_mouse_pos()` read the cursor position from the $E0 text-page screen holes ($047C etc.). Under GS/OS 6.0.1 those copies are never updated — the Event Manager maintains the live cursor position only in the $E1/0190-0193 bank globals — so the host-follows-guest mouse sync got stuck at (0,0).

This reads the bank globals instead. Fixes the host mouse not tracking the guest cursor on the IIgs desktop.

**Testing:** built and run against GS/OS 6.0.1 (ROM 03); the cursor now tracks correctly. Found while getting System 6.0.1 to boot for automated testing.

Single-file change, no behaviour change outside the IIgs mouse path.