### PR TITLE
Derive bank $FF offset from ROM size — ROM 03 (256K) support

### DIFF
--- a/src/gs2.cpp
+++ b/src/gs2.cpp
@@ -775,8 +775,21 @@ void transition_to_emulation(GS2AppState *state, const SystemConfig_t *system_co
             computer->debug_window->set_mmu(state->mmu_iie);
             break;
         case MMU_MMU_IIGS:
-            state->mmu_iie = new MMU_IIe(256, 128*1024, /* (uint8_t *) */rd->main_rom_data + 0x1'C000);
-            state->mmu_iigs = new MMU_IIgs(256, 8*1024*1024, 128*1024, /* (uint8_t *) */rd->main_rom_data, state->mmu_iie);
+        {
+            // Bank $FF (the IIe-compatibility ROM the emulation-mode 6502
+            // core runs, and the source for the LC-area/IOLC ROM overlay
+            // reads inside MMU_IIgs) is always the *last* 64K bank of the
+            // ROM image, wherever that falls for the actual ROM size --
+            // NOT a hardcoded 128KB-ROM (ROM01) assumption. ROM01 is 128KB
+            // (bank $FF at file offset 0x10000); ROM03 is 256KB (0x30000).
+            // Previously hardcoded to 0x1'C000 / 128*1024, which silently
+            // only worked for a 128KB ROM01 image and scrambled the bank
+            // layout (and the emulation-mode reset vector) for ROM03.
+            const size_t main_rom_size = rd->main_rom_file->size();
+            const size_t rom_bank_ff_offset = main_rom_size - 65536;
+            state->mmu_iie = new MMU_IIe(256, 128*1024, /* (uint8_t *) */rd->main_rom_data + rom_bank_ff_offset + 0xC000);
+            state->mmu_iigs = new MMU_IIgs(256, 8*1024*1024, (uint32_t) main_rom_size, /* (uint8_t *) */rd->main_rom_data, state->mmu_iie);
+        }
             state->mmu_iigs->init_map();
             computer->cpu->set_mmu(state->mmu_iigs); // cpu gets FPI
             computer->set_mmu(state->mmu_iie); // everything else gets the Mega II

--- a/src/mmus/mmu_iigs.cpp
+++ b/src/mmus/mmu_iigs.cpp
@@ -551,7 +551,7 @@ uint8_t bank_shadow_read(void *context, uint32_t address) {
             // rom
             mmu_iigs->set_next_cycle_type(CYCLE_TYPE_FAST_ROM); // even though it's in "LC" area it's ROM. 
             if (DEBUG(DEBUG_MMUGS)) printf("Read: ROM Effective address: %06X\n", address);
-            return mmu_iigs->get_rom_base()[0x1'0000 + (address & 0xFFFF)]; // TODO: this is only for ROM01. ROM03 has more ROM needs different offset. Have a routine to calculate.
+            return mmu_iigs->get_rom_base()[mmu_iigs->rom_bank_ff_offset() + (address & 0xFFFF)];
         }
     }
     // we know at this point we were not originally C0 IO space. so.. 
@@ -601,7 +601,7 @@ void bank_shadow_write(void *context, uint32_t address, uint8_t value) {
 
 uint8_t iolc_rom_read(void *context, uint32_t address) {
     MMU_IIgs *mmu_iigs = (MMU_IIgs *)context;
-    return mmu_iigs->get_rom_base()[0x1'0000 + (address & 0xFFFF)];
+    return mmu_iigs->get_rom_base()[mmu_iigs->rom_bank_ff_offset() + (address & 0xFFFF)];
 }
 
 read_handler_t float_read_handler = { (memory_read_func)float_area_read, nullptr };
@@ -693,7 +693,7 @@ void MMU_IIgs::init_map() {
 
     // use new routine.
     for (int i = 1; i < 16; i++) {
-        megaii->map_c1cf_internal_rom(0xC0 + i, main_rom + 0x1'C000 + i * GS2_PAGE_SIZE, "GS INT");
+        megaii->map_c1cf_internal_rom(0xC0 + i, main_rom + rom_bank_ff_offset() + 0xC000 + i * GS2_PAGE_SIZE, "GS INT");
     }
 
     /* megaii->set_slot_rom(SLOT_1, main_rom + 0x1'C100, "GS INT");
@@ -781,7 +781,7 @@ void MMU_IIgs::debug_dump(DebugFormatter *df) {
 
 uint8_t MMU_IIgs::vp_read(uint32_t address) {
     if (is_iolc_shadowed()) { // if IOLC is shadowed, read from ROM.
-        return get_rom_base()[0x1'0000 + (address & 0xFFFF)];
+        return get_rom_base()[rom_bank_ff_offset() + (address & 0xFFFF)];
     } else {
         return read(address);
     }

--- a/src/mmus/mmu_iigs.hpp
+++ b/src/mmus/mmu_iigs.hpp
@@ -196,6 +196,15 @@ class MMU_IIgs : public MMU {
         uint8_t read_c0xx(uint16_t address);
         
         virtual uint8_t *get_rom_base() { return main_rom; };
+
+        // Byte offset within main_rom of the start of virtual bank $FF (the
+        // top bank, always the *last* physical bank in the ROM image
+        // regardless of total ROM size). ROM01 is 2 banks (128KB) -> 0x10000;
+        // ROM03 is 4 banks (256KB) -> 0x30000. Fixed-offset lookups (LC-area
+        // ROM overlay reads, the $C100-$CFFF slot-firmware mapping, the
+        // embedded IIe-compat ROM pointer) key off bank $FF and used to
+        // hardcode 0x10000, silently only correct for a 128KB ROM.
+        inline uint32_t rom_bank_ff_offset() const { return (rom_banks - 1) * BANK_SIZE; }
         uint8_t *get_memory_base() override { return main_ram; }
         uint32_t get_memory_size() override { return ram_banks * BANK_SIZE; }
         virtual void init_map();


### PR DESCRIPTION
The IIgs MMU hardcoded virtual bank $FF at file offset `0x10000` (and the IIe-compat ROM pointer at `0x1'C000`, ROM size `128*1024`). That's correct only for a 128K ROM 01 image. A 256K ROM 03 has bank $FF at `0x30000`, so with a ROM 03 the reset vector and every fixed-offset ROM lookup were scrambled and the machine couldn't come up.

`rom_banks` is already computed from `rom_size` in the `MMU_IIgs` ctor; this adds `rom_bank_ff_offset() = (rom_banks-1)*BANK_SIZE` and uses it at the four fixed-offset sites, and passes the real ROM size from `gs2.cpp` instead of the `128*1024` literal.

- ROM 01 (2 banks) → `0x10000`, unchanged.
- ROM 03 (4 banks) → `0x30000`, now correct.

**Testing:** built; with a ROM 03 image the splash reports "ROM Version 3" and the reset vector reads correctly (previously scrambled). No change for ROM 01.

Found while bringing up GS/OS 6.0.1 on ROM 03 for automated testing.