### PR TITLE
Add an Apple IIgs (ROM 3) machine

### DIFF
--- a/assets/roms/apple2gs_rom3/README.md
+++ b/assets/roms/apple2gs_rom3/README.md
@@ -12,4 +12,5 @@ your own dumps:
 Drop both files here and select **Apple IIgs (ROM 3)** in the machine
 picker. The IIgs MMU derives the bank `$FF` offset from the ROM size, so
 the 256K image maps correctly (the stock `apple2gs` machine uses a 128K
-ROM 01 image).
+ROM 01 image). ROM 03-specific hardware behavior is implemented
+incrementally; this profile starts from the existing Apple IIgs device map.

--- a/assets/roms/apple2gs_rom3/README.md
+++ b/assets/roms/apple2gs_rom3/README.md
@@ -1,0 +1,15 @@
+# Apple IIgs ROM 3
+
+The **Apple IIgs (ROM 3)** machine loads its firmware from this directory.
+The ROM images are Apple copyright and are not distributed here — supply
+your own dumps:
+
+| File | Size | What |
+|------|------|------|
+| `main.rom` | 262144 (256K) | Apple IIgs ROM 03 main ROM |
+| `char.rom` | 16384 (16K)  | IIgs character generator (same as `../apple2gs/char.rom`) |
+
+Drop both files here and select **Apple IIgs (ROM 3)** in the machine
+picker. The IIgs MMU derives the bank `$FF` offset from the ROM size, so
+the 256K image maps correctly (the stock `apple2gs` machine uses a 128K
+ROM 01 image).

--- a/src/PlatformIDs.hpp
+++ b/src/PlatformIDs.hpp
@@ -9,6 +9,7 @@ typedef enum PlatformId_t {
     PLATFORM_APPLE_IIE_ENHANCED,
     PLATFORM_APPLE_IIE_65816,
     PLATFORM_APPLE_IIGS,
+    PLATFORM_APPLE_IIGS_ROM3,
     PLATFORM_END
 } PlatformId_t;
 
@@ -20,4 +21,5 @@ const PlatformFlags_t PLATFLAG_APPLE_IIE = 1 << 2;
 const PlatformFlags_t PLATFLAG_APPLE_IIE_ENHANCED = 1 << 3;
 const PlatformFlags_t PLATFLAG_APPLE_IIE_65816 = 1 << 4;
 const PlatformFlags_t PLATFLAG_APPLE_IIGS = 1 << 5;
+const PlatformFlags_t PLATFLAG_APPLE_IIGS_ROM3 = 1 << 6;
 const PlatformFlags_t PLATFLAG_ALL = 0xFFFFFFFF;

--- a/src/gs2.cpp
+++ b/src/gs2.cpp
@@ -775,8 +775,21 @@ void transition_to_emulation(GS2AppState *state, const SystemConfig_t *system_co
             computer->debug_window->set_mmu(state->mmu_iie);
             break;
         case MMU_MMU_IIGS:
-            state->mmu_iie = new MMU_IIe(256, 128*1024, /* (uint8_t *) */rd->main_rom_data + 0x1'C000);
-            state->mmu_iigs = new MMU_IIgs(256, 8*1024*1024, 128*1024, /* (uint8_t *) */rd->main_rom_data, state->mmu_iie);
+        {
+            // Bank $FF (the IIe-compatibility ROM the emulation-mode 6502
+            // core runs, and the source for the LC-area/IOLC ROM overlay
+            // reads inside MMU_IIgs) is always the *last* 64K bank of the
+            // ROM image, wherever that falls for the actual ROM size --
+            // NOT a hardcoded 128KB-ROM (ROM01) assumption. ROM01 is 128KB
+            // (bank $FF at file offset 0x10000); ROM03 is 256KB (0x30000).
+            // Previously hardcoded to 0x1'C000 / 128*1024, which silently
+            // only worked for a 128KB ROM01 image and scrambled the bank
+            // layout (and the emulation-mode reset vector) for ROM03.
+            const size_t main_rom_size = rd->main_rom_file->size();
+            const size_t rom_bank_ff_offset = main_rom_size - 65536;
+            state->mmu_iie = new MMU_IIe(256, 128*1024, /* (uint8_t *) */rd->main_rom_data + rom_bank_ff_offset + 0xC000);
+            state->mmu_iigs = new MMU_IIgs(256, 8*1024*1024, (uint32_t) main_rom_size, /* (uint8_t *) */rd->main_rom_data, state->mmu_iie);
+        }
             state->mmu_iigs->init_map();
             computer->cpu->set_mmu(state->mmu_iigs); // cpu gets FPI
             computer->set_mmu(state->mmu_iie); // everything else gets the Mega II

--- a/src/mmus/mmu_iigs.cpp
+++ b/src/mmus/mmu_iigs.cpp
@@ -551,7 +551,7 @@ uint8_t bank_shadow_read(void *context, uint32_t address) {
             // rom
             mmu_iigs->set_next_cycle_type(CYCLE_TYPE_FAST_ROM); // even though it's in "LC" area it's ROM. 
             if (DEBUG(DEBUG_MMUGS)) printf("Read: ROM Effective address: %06X\n", address);
-            return mmu_iigs->get_rom_base()[0x1'0000 + (address & 0xFFFF)]; // TODO: this is only for ROM01. ROM03 has more ROM needs different offset. Have a routine to calculate.
+            return mmu_iigs->get_rom_base()[mmu_iigs->rom_bank_ff_offset() + (address & 0xFFFF)];
         }
     }
     // we know at this point we were not originally C0 IO space. so.. 
@@ -601,7 +601,7 @@ void bank_shadow_write(void *context, uint32_t address, uint8_t value) {
 
 uint8_t iolc_rom_read(void *context, uint32_t address) {
     MMU_IIgs *mmu_iigs = (MMU_IIgs *)context;
-    return mmu_iigs->get_rom_base()[0x1'0000 + (address & 0xFFFF)];
+    return mmu_iigs->get_rom_base()[mmu_iigs->rom_bank_ff_offset() + (address & 0xFFFF)];
 }
 
 read_handler_t float_read_handler = { (memory_read_func)float_area_read, nullptr };
@@ -693,7 +693,7 @@ void MMU_IIgs::init_map() {
 
     // use new routine.
     for (int i = 1; i < 16; i++) {
-        megaii->map_c1cf_internal_rom(0xC0 + i, main_rom + 0x1'C000 + i * GS2_PAGE_SIZE, "GS INT");
+        megaii->map_c1cf_internal_rom(0xC0 + i, main_rom + rom_bank_ff_offset() + 0xC000 + i * GS2_PAGE_SIZE, "GS INT");
     }
 
     /* megaii->set_slot_rom(SLOT_1, main_rom + 0x1'C100, "GS INT");
@@ -781,7 +781,7 @@ void MMU_IIgs::debug_dump(DebugFormatter *df) {
 
 uint8_t MMU_IIgs::vp_read(uint32_t address) {
     if (is_iolc_shadowed()) { // if IOLC is shadowed, read from ROM.
-        return get_rom_base()[0x1'0000 + (address & 0xFFFF)];
+        return get_rom_base()[rom_bank_ff_offset() + (address & 0xFFFF)];
     } else {
         return read(address);
     }

--- a/src/mmus/mmu_iigs.hpp
+++ b/src/mmus/mmu_iigs.hpp
@@ -74,6 +74,7 @@ class MMU_IIgs : public MMU {
             ram_banks = ram_size / BANK_SIZE;
             main_ram = new uint8_t[ram_banks * BANK_SIZE];
             rom_banks = rom_size / BANK_SIZE;
+            is_rom03 = rom_banks >= 4;
             main_rom = rom;
             map_initialized = false;
             reset();

--- a/src/mmus/mmu_iigs.hpp
+++ b/src/mmus/mmu_iigs.hpp
@@ -196,6 +196,15 @@ class MMU_IIgs : public MMU {
         uint8_t read_c0xx(uint16_t address);
         
         virtual uint8_t *get_rom_base() { return main_rom; };
+
+        // Byte offset within main_rom of the start of virtual bank $FF (the
+        // top bank, always the *last* physical bank in the ROM image
+        // regardless of total ROM size). ROM01 is 2 banks (128KB) -> 0x10000;
+        // ROM03 is 4 banks (256KB) -> 0x30000. Fixed-offset lookups (LC-area
+        // ROM overlay reads, the $C100-$CFFF slot-firmware mapping, the
+        // embedded IIe-compat ROM pointer) key off bank $FF and used to
+        // hardcode 0x10000, silently only correct for a 128KB ROM.
+        inline uint32_t rom_bank_ff_offset() const { return (rom_banks - 1) * BANK_SIZE; }
         uint8_t *get_memory_base() override { return main_ram; }
         uint32_t get_memory_size() override { return ram_banks * BANK_SIZE; }
         virtual void init_map();

--- a/src/platforms.cpp
+++ b/src/platforms.cpp
@@ -140,6 +140,31 @@ static  platform_info platforms[] = {
             DEVICE_ID_END
         }
      },
+     {
+        // Same hardware as the ROM 01 Apple IIgs above, but loads a 256K
+        // ROM 03 image (roms/apple2gs_rom3/main.rom). The MMU derives the
+        // bank $FF offset from the ROM size, so the larger image maps
+        // correctly. Drop a ROM 03 dump in assets/roms/apple2gs_rom3/.
+        PLATFORM_APPLE_IIGS_ROM3,
+        "Apple IIgs (ROM 3)",
+        "apple2gs_rom3",
+        PROCESSOR_65816,
+        0xC7C9C7FF,    //0xD2D0C8FF,
+        Badge_IIGS,
+        CLOCK_2_8MHZ,
+        MMU_MMU_IIGS,
+        {
+            DEVICE_ID_SPEAKER,     // speaker must be before display so iigs can override some things?? Still a thing?
+            DEVICE_ID_DISPLAY,
+            DEVICE_ID_KEYGLOO,     // Keyboard should be before IIGS_MEMORY
+            DEVICE_ID_RTC_PRAM,
+            DEVICE_ID_GAMECONTROLLER,
+            DEVICE_ID_ENSONIQ,
+            DEVICE_ID_SCC8530,
+            DEVICE_ID_IWM,
+            DEVICE_ID_END
+        }
+     },
     // Add more platforms as needed:
     // { "Apple IIc",         "apple2c" },
     // { "Apple IIc Plus",    "apple2c_plus" },

--- a/src/platforms.cpp
+++ b/src/platforms.cpp
@@ -141,10 +141,9 @@ static  platform_info platforms[] = {
         }
      },
      {
-        // Same hardware as the ROM 01 Apple IIgs above, but loads a 256K
-        // ROM 03 image (roms/apple2gs_rom3/main.rom). The MMU derives the
-        // bank $FF offset from the ROM size, so the larger image maps
-        // correctly. Drop a ROM 03 dump in assets/roms/apple2gs_rom3/.
+        // ROM 03 firmware profile. It shares the current Apple IIgs device
+        // map, loads a 256K image (roms/apple2gs_rom3/main.rom), and lets
+        // the MMU enable ROM 03-specific behavior from the ROM size.
         PLATFORM_APPLE_IIGS_ROM3,
         "Apple IIgs (ROM 3)",
         "apple2gs_rom3",

--- a/src/systemconfig.cpp
+++ b/src/systemconfig.cpp
@@ -236,6 +236,27 @@ SystemConfig_t BuiltinSystemConfigs[] = {
             DEVICE_ID_PD_BLOCK3,
         }
     },
+    {
+        "Apple IIgs (ROM 3)",
+        PLATFORM_APPLE_IIGS_ROM3,
+        //DeviceMap_IIGS,
+        //Badge_IIGS,
+        true,
+        CLOCK_SET_US,
+        Scanner_AppleIIgs,
+        "Apple IIgs (ROM 3) 8MB RAM",
+        "ec541ad4-f57c-4889-96b8-9c854b11dd10",
+        {
+            DEVICE_ID_NONE,
+            DEVICE_ID_NONE,
+            DEVICE_ID_NONE,
+            DEVICE_ID_SECOND_SIGHT,
+            DEVICE_ID_NONE,
+            DEVICE_ID_NONE,
+            DEVICE_ID_NONE,
+            DEVICE_ID_PD_BLOCK3,
+        }
+    },
 /*     {
         "Apple IIc",
         PLATFORM_APPLE_IIC,


### PR DESCRIPTION
Adds a distinct **Apple IIgs (ROM 3)** machine that loads a 256K ROM 03 image from `roms/apple2gs_rom3/`, alongside the existing 128K ROM 01 `Apple IIgs`.

This is an initial ROM 3 firmware profile on the current IIgs device map, not a claim that every 1 MB IIgs hardware delta is complete. The branch now also enables the emulator’s existing ROM 03-only text page 2 shadowing path when a 256K IIgs ROM is loaded.

- `PlatformIDs.hpp`: `PLATFORM_APPLE_IIGS_ROM3` (+ flag), appended so existing platform numbers are unchanged.
- `platforms.cpp`: the machine definition (`rom_dir = apple2gs_rom3`) with wording scoped to a ROM 03 firmware profile.
- `systemconfig.cpp`: a built-in config so it shows in the machine picker.
- `mmu_iigs`: derives the ROM 03 profile from the 256K ROM size so text page 2 shadowing is enabled for this path. #136 remains the bank-$FF-from-ROM-size fix that maps the larger ROM image correctly.
- `assets/roms/apple2gs_rom3/README.md`: documents the two ROM files to supply. **No ROM binary is bundled** — the images are Apple copyright, so it is bring-your-own (`main.rom` 256K + `char.rom` in that dir). Selecting the machine without them fails with the usual clear "ROM not found" error; nothing else is affected.

**Stacked on #136** — this branch includes that commit. Once #136 merges this reduces to the ROM 3 platform/profile change plus the text page 2 shadowing activation.

**Testing:**
- `cmake -S . -B /tmp/gssquared-pr138-build -DGS2_BUILD_NATIVE=ON -DGS2_PROGRAM_FILES=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/gssquared-pr138-build -j4`
- `ctest --test-dir /tmp/gssquared-pr138-build --output-on-failure` currently fails the pre-existing `systemconfigtest` fixture checks unrelated to this MMU/platform change (18/21 checks pass; failures are aliases/card extras/connections).